### PR TITLE
usage is not shown when user didn't supply arguments

### DIFF
--- a/atitweak
+++ b/atitweak
@@ -353,7 +353,7 @@ if __name__ == "__main__":
             list_adapters(adapter_list=adapter_list)
         elif options.action == "status":
             show_status(adapter_list=adapter_list)
-        elif options.action is None:
+        elif options.action is None and len(sys.argv) > 1:
             if options.engine_clock or options.memory_clock or options.core_voltage:
                 set_plevels(adapter_list=adapter_list,
                             plevel_list=plevel_list,


### PR DESCRIPTION
If the script is started without arguments, the usage wasn't shown leaving the user puzzled on what just happened. 

Maybe module argparse should be used instead of optparse in the future.
